### PR TITLE
Calculate pmf in generated quantities

### DIFF
--- a/R/utils_longitudinal.R
+++ b/R/utils_longitudinal.R
@@ -42,7 +42,7 @@ get_index <- function(train, test = NULL) {
   tmp <- full_df %>%
     group_by(.data$Patient) %>%
     summarise(t_max = max(.data$Time)) %>%
-    arrange(Patient)
+    arrange(.data$Patient)
 
   out <- lapply(1:nrow(tmp),
                 function(i) {


### PR DESCRIPTION
Currently implemented in OrderedRW.
This simplify the `generated quantities` and allow to extract the pmf.
However it may be come with a computational cost, so this remains to be investigated.